### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
 # GitHub MCP Server for Pera1
 
+[![smithery badge](https://smithery.ai/badge/@kazuph/mcp-github-pera1)](https://smithery.ai/server/@kazuph/mcp-github-pera1)
+
 A Model Context Protocol server that connects GitHub code to Claude.ai. This server utilizes the Pera1 service to extract code from GitHub repositories and provide better context to Claude.
 
 <a href="https://glama.ai/mcp/servers/m2sd6ew3wf"><img width="380" height="200" src="https://glama.ai/mcp/servers/m2sd6ew3wf/badge" alt="@kazuph/mcp-github-pera1 MCP server" /></a>
+
+
+### Installing via Smithery
+
+To install GitHub MCP Server for Pera1 for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@kazuph/mcp-github-pera1):
+
+```bash
+npx -y @smithery/cli install @kazuph/mcp-github-pera1 --client claude
+```
 
 ### Setup
 


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install GitHub MCP Server for Pera1 for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/@kazuph/mcp-github-pera1

Let me know if any tweaks have to be made!