### PR TITLE
Fix npm auth in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,11 +17,15 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
       - run: pnpm audit
       - name: Configure npm authentication
-        run: echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+        run: |
+          npm config set //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
+          npm config set //registry.npmjs.org/:always-auth true
+          pnpm config set //registry.npmjs.org/:_authToken ${NODE_AUTH_TOKEN} --global
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish package


### PR DESCRIPTION
## Summary
- configure setup-node with the npm registry URL
- write auth token for both npm and pnpm so publish uses the secret

## Testing
- not run (workflow-only change)