### PR TITLE
ci: fix publish workflow (provenance + skip-if-exists)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,9 +5,9 @@ on:
     branches:
       - main
 
-
 permissions:
-  contents: read
+  # Needed for creating tags/releases; OIDC for npm provenance
+  contents: write
   id-token: write
 
 concurrency:
@@ -18,43 +18,60 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
         with:
           version: 10.15.0
-      - uses: actions/setup-node@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm test
-      - run: pnpm audit
-      - name: Publish package
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Test
+        run: pnpm test
+
+      - name: Determine package info
+        id: pkg
+        run: |
+          NAME=$(node -p "require('./package.json').name")
+          VERSION=$(node -p "require('./package.json').version")
+          echo "name=$NAME" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Package: $NAME@$VERSION"
+
+      - name: Check if version already published
+        id: check
+        run: |
+          if npm view "${{ steps.pkg.outputs.name }}@${{ steps.pkg.outputs.version }}" version >/dev/null 2>&1; then
+            echo "already=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "already=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm (with provenance)
+        if: steps.check.outputs.already == 'false'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
-      - name: Determine package version
-        id: package_version
-        run: |
-          VERSION="v$(node -p "require('./package.json').version")"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-      - name: Check for existing release
-        id: release_check
-        run: |
-          if gh release view "${{ steps.package_version.outputs.version }}" >/dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm publish --provenance --access public
+
       - name: Create GitHub release
-        if: steps.release_check.outputs.exists == 'false'
+        if: steps.check.outputs.already == 'false'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.package_version.outputs.version }}
-          name: ${{ steps.package_version.outputs.version }}
+          tag_name: v${{ steps.pkg.outputs.version }}
+          name: v${{ steps.pkg.outputs.version }}
           generate_release_notes: true
           target_commitish: ${{ github.sha }}
         env:


### PR DESCRIPTION
 - Publish with npm provenance
 - Skip if version already on npm (avoid needless bumps)
 - Create GitHub Release only when publish happens
 - Remove audit from publish job

No version bump included.