### PR TITLE
ci: add npm preflight; stabilize publish (provenance + skip-if-exists)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,25 @@ jobs:
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Validate required secrets (NPM_TOKEN)
+        if: ${{ secrets.NPM_TOKEN == '' }}
+        run: |
+          echo "Missing NPM_TOKEN secret.\nSet it in: Settings > Secrets and variables > Actions > New repository secret (name: NPM_TOKEN)." >&2
+          exit 1
+
+      - name: Preflight npm authentication
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Write token for whoami preflight without printing it
+          printf "//registry.npmjs.org/:_authToken=%s\n" "$NODE_AUTH_TOKEN" > ~/.npmrc
+          npm whoami --registry=https://registry.npmjs.org >/dev/null 2>&1 || {
+            echo "NPM_TOKEN is invalid or lacks access. Please reissue an Automation token with publish rights." >&2
+            exit 1
+          }
+          echo "npm auth preflight OK"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 


### PR DESCRIPTION
- Add preflight steps: NPM_TOKEN presence + npm whoami
- Keep provenance publish and release-on-publish
- No version bump