### PR TITLE
ci: use NPM_TOKEN directly; stable publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,16 +34,17 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Preflight npm authentication
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
-          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+          TOKEN="${{ secrets.NPM_TOKEN }}"
+          if [ -z "$TOKEN" ]; then
             echo "Missing NPM_TOKEN secret.\nSet it in: Settings > Secrets and variables > Actions as NPM_TOKEN (Automation token with publish)." >&2
             exit 1
           fi
-          # Write token for whoami preflight without printing it
-          printf "//registry.npmjs.org/:_authToken=%s\n" "$NODE_AUTH_TOKEN" > ~/.npmrc
+          # Use the npm user config path that setup-node exports
+          : "${NPM_CONFIG_USERCONFIG:=~/.npmrc}"
+          install -d "$(dirname "$NPM_CONFIG_USERCONFIG")"
+          printf "//registry.npmjs.org/:_authToken=%s\n" "$TOKEN" > "$NPM_CONFIG_USERCONFIG"
           if ! npm whoami --registry=https://registry.npmjs.org >/dev/null 2>&1; then
             echo "NPM_TOKEN is invalid or lacks access. Reissue an Automation token with publish rights." >&2
             exit 1
@@ -79,8 +80,6 @@ jobs:
 
       - name: Publish to npm (with provenance)
         if: steps.check.outputs.already == 'false'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --access public
 
       - name: Create GitHub release


### PR DESCRIPTION
- Preflight writes NPM_TOKEN to $NPM_CONFIG_USERCONFIG
- Remove NODE_AUTH_TOKEN
- No version bump